### PR TITLE
add an event listener for local_update_applied events

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,16 +2,6 @@ var $fh = require('fh-js-sdk');
 
 
 console.log('TEST', $fh.sync);
-        console.log('window.location.href', window.location.href);
+console.log('window.location.href', window.location.href);
 
 var datasetId = 'myShoppingList';
-
-
-$fh.sync.init({
-  "do_console_log" : true,
-  "storage_strategy" : "dom"
-});
-
-$fh.sync.notify(function(notification) {
-  console.log('notify', notification);
-});

--- a/main.js
+++ b/main.js
@@ -3,19 +3,10 @@ var $fh = require('fh-js-sdk');
 
 
 console.log('TEST', $fh.sync);
-        console.log('window.location.href', window.location.href);
+console.log('window.location.href', window.location.href);
 
 var datasetId = 'myShoppingList';
 
-
-$fh.sync.init({
-  "do_console_log" : true,
-  "storage_strategy" : "dom"
-});
-
-$fh.sync.notify(function(notification) {
-  console.log('notify', notification);
-});
 },{"fh-js-sdk":2}],2:[function(require,module,exports){
 (function (global){
 !function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.feedhenry=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
@@ -12399,6 +12390,7 @@ var self = {
         failure("unknown_uid");
       } else {
         // Return a copy of the record so updates will not automatically make it back into the dataset
+        console.log(JSON.stringify(rec));
         var res = JSON.parse(JSON.stringify(rec));
         success(res);
       }
@@ -13609,5 +13601,6 @@ module.exports = {
 },{"./appProps":29,"./constants":31,"./data":33,"./events":35,"./fhparams":36,"./hosts":38,"./initializer":39,"./logger":42}]},{},[19])
 (19)
 });
+
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{}]},{},[1]);

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -82,27 +82,36 @@ describe('Sync', function() {
      }));
   });
 
-  // it('should read', function() {
-  //   return new Promise(function(resolve, reject) {
-  //     $fh.sync.doRead(datasetId, dataId, function(data) {
-  //       expect(data.data).toEqual(testData);
-  //       resolve();
-  //     }, function(code, msg) {
-  //       reject(code + ': ' + msg);
-  //     });
-  //   });
-  // });
+  it('should read', function() {
+    return new Promise(function(resolve, reject) {
+      $fh.sync.manage(datasetId, {}, {}, {}, function() {
+        $fh.sync.doCreate(datasetId, testData, function(res) {
+          $fh.sync.doRead(datasetId, res.uid, function(data) {
+            expect(data.data).toEqual(testData);
+            expect(data.hash).not.toBeNull();
+            return resolve();
+          }, function(msg) {
+             reject(code + ': ' + msg);
+          });
+        });
+      });
+    });
+  });
 
-  // it('should fail reading unknown uid', function() {
-  //   return new Promise(function(resolve, reject) {
-  //     $fh.sync.doRead(datasetId, 'nonsence', function(data) {
-  //       reject(data);
-  //     }, function(code) {
-  //       expect(code).toBe('unknown_uid');
-  //       resolve();
-  //     });
-  //   });
-  // });
+  it('should fail when reading unknown uid', function() {
+    return new Promise(function(resolve, reject) {
+      $fh.sync.manage(datasetId, {}, {}, {}, function() {
+        $fh.sync.doCreate(datasetId, testData, function(res) {
+          $fh.sync.doRead(datasetId, 'bogus uid', function(data) {
+            return reject('doRead should have returned error unknown_uid');
+          }, function(err) {
+            expect(err).toEqual('unknown_uid');
+            resolve();
+          });
+        });
+      });
+    });
+  });
 
   // it('should update', function() {
   //   return new Promise(function(resolve, reject) {

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -113,20 +113,24 @@ describe('Sync', function() {
     });
   });
 
-  // it('should update', function() {
-  //   return new Promise(function(resolve, reject) {
-  //     $fh.sync.doUpdate(datasetId, dataId, updateData, function() {
-  //       $fh.sync.doRead(datasetId, dataId, function(data) {
-  //         expect(data.data).toEqual(updateData);
-  //         resolve();
-  //       }, function(code, msg) {
-  //         reject(code + ': ' + msg);
-  //       });
-  //     }, function(code, msg) {
-  //       reject(code + ': ' + msg);
-  //     });
-  //   });
-  // });
+  it('should update', function() {
+    return new Promise(function(resolve, reject) {
+      $fh.sync.manage(datasetId, {}, {}, {}, function() {
+        $fh.sync.doCreate(datasetId, testData, function(res) {
+          $fh.sync.doUpdate(datasetId, res.uid, updateData, function() {
+            $fh.sync.doRead(datasetId, res.uid, function(data) {
+              expect(data.data).toEqual(updateData);
+              return resolve();
+            }, function (err) {
+               reject(err);
+            });
+          }, function (err) {
+               reject(err);
+          });
+        });
+      });
+    });
+  });
 
   // it('should delete', function() {
   //   return new Promise(function(resolve, reject) {

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -35,13 +35,7 @@ describe('Sync', function() {
   });
 
   it('should list', function() {
-    return new Promise(function(resolve, reject) {
-      $fh.sync.manage(datasetId, {}, {}, {}, function() {
-        $fh.sync.doList(datasetId, resolve, function(code, msg) {
-          return reject(code + ': ' + msg);
-        });
-      });
-    })
+    return manage()
     .then(waitForSyncEvent('sync_started', function(event, resolve, reject) {
       expect(event.dataset_id).toEqual(datasetId);
       expect(event.message).toBeNull();
@@ -63,16 +57,11 @@ describe('Sync', function() {
         expect(event.message).toMatch(/(load|create)/);
       }
     });
-    return new Promise(function(resolve, reject) {
-      $fh.sync.manage(datasetId, {}, {}, {}, function() {
-        $fh.sync.doCreate(datasetId, testData, function(res) {
-          expect(res.action).toEqual('create');
-          expect(res.post).toEqual(testData);
-          return resolve();
-        }, function(code, msg) {
-          reject(code + ': ' + msg);
-        });
-      });
+    return manage()
+    .then(doCreate)
+    .then(function (res) {
+      expect(res.action).toEqual('create');
+      expect(res.post).toEqual(testData);
     })
     .then(waitForSyncEvent('remote_update_applied', function(event, resolve, reject) {
        expect(event.dataset_id).toEqual(datasetId);

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -188,4 +188,55 @@ describe('Sync', function() {
     });
   });
 
+  it('should delete', function() {
+    return manage()
+    .then(doCreate)
+    .then(doDelete())
+    .then(doRead())
+    .catch(function (err) {
+      expect(err).toEqual('unknown_uid');
+      console.log("Catch...", err);
+    });
+  });
+
 });
+
+function manage() {
+  return new Promise(function (resolve, reject) {
+    $fh.sync.manage(datasetId, {}, {}, {}, function() {
+      return resolve();
+    });
+  });
+}
+
+function doCreate() {
+  return new Promise(function(resolve, reject) {
+    $fh.sync.doCreate(datasetId, testData, function(res) {
+      return resolve(res);
+    }, function (err) {
+      reject(err);
+    });
+  });
+}
+
+function doDelete() {
+  return function(res) {
+    return new Promise(function(resolve, reject) {
+      $fh.sync.doDelete(datasetId, res.uid, function() {
+        return resolve(res);
+      });
+    });
+  };
+}
+
+function doRead() {
+  return function(res) {
+    return new Promise(function(resolve, reject) {
+      $fh.sync.doRead(datasetId, res.uid, function(data) {
+        return resolve(data);
+      }, function failure(err) {
+         reject(err);
+      });
+    });
+  };
+}

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -43,6 +43,11 @@ describe('Sync', function() {
         });
       });
     })
+    .then(waitForSyncEvent('sync_started', function(event, resolve, reject) {
+      expect(event.dataset_id).toEqual(datasetId);
+      expect(event.message).toBeNull();
+      return resolve();
+    }))
     .then(waitForSyncEvent('sync_complete', function(event, resolve, reject) {
       // log: !!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT, sync_started, {"dataset_id":"specDataset","uid":null,"code":"sync_started","message":null}
       // log: !!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT, sync_complete, {"dataset_id":"specDataset","uid":"a2a57278171a23df4441b60238f7802a10e95970","code":"sync_complete","message":"online"}

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -83,49 +83,24 @@ describe('Sync', function() {
   });
 
   it('should read', function() {
-    return new Promise(function manage(resolve, reject) {
-      $fh.sync.manage(datasetId, {}, {}, {}, function() {
-        return resolve();
-      })
-    }).then(function doCreate() {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doCreate(datasetId, testData, function(res) {
-          return resolve(res);
-        });
-      });
-    }).then(function doRead(res) {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doRead(datasetId, res.uid, function(data) {
-            expect(data.data).toEqual(testData);
-            expect(data.hash).not.toBeNull();
-            return resolve();
-        }, function failure(err) {
-           reject(err);
-        });
-      });
+    return manage()
+    .then(doCreate)
+    .then(doRead())
+    .then(function (data) {
+      expect(data.data).toEqual(testData);
+      expect(data.hash).not.toBeNull();
+    })
+    .catch(function (err) {
+      expect(err).toBeNull();
     });
   });
 
   it('should fail when reading unknown uid', function() {
-    return new Promise(function manage(resolve, reject) {
-      $fh.sync.manage(datasetId, {}, {}, {}, function() {
-        return resolve();
-      })
-    }).then(function doCreate() {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doCreate(datasetId, testData, function(res) {
-          return resolve(res);
-        });
-      });
-    }).then(function doRead(res) {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doRead(datasetId, 'bogus uid', function(data) {
-          return reject('Item with uid ' + res.uid + '  should have been deleted');
-        }, function failure(err) {
-           expect(err).toEqual('unknown_uid');
-           resolve();
-        });
-      });
+    return manage()
+    .then(doCreate)
+    .then(doRead('bogus_uid'))
+    .catch(function (err) {
+      expect(err).toEqual('unknown_uid');
     });
   });
 
@@ -182,10 +157,10 @@ function doDelete() {
   };
 }
 
-function doRead() {
+function doRead(uid) {
   return function(res) {
     return new Promise(function(resolve, reject) {
-      $fh.sync.doRead(datasetId, res.uid, function(data) {
+      $fh.sync.doRead(datasetId, uid || res.uid, function(data) {
         return resolve(data);
       }, function failure(err) {
         reject(err);

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -114,21 +114,32 @@ describe('Sync', function() {
   });
 
   it('should update', function() {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function manage(resolve, reject) {
       $fh.sync.manage(datasetId, {}, {}, {}, function() {
+        return resolve();
+      })
+    }).then(function doCreate() {
+      return new Promise(function(resolve, reject) {
         $fh.sync.doCreate(datasetId, testData, function(res) {
-          $fh.sync.doUpdate(datasetId, res.uid, updateData, function() {
-            $fh.sync.doRead(datasetId, res.uid, function(data) {
-              expect(data.data).toEqual(updateData);
-              return resolve();
-            }, function (err) {
-               reject(err);
-            });
-          }, function (err) {
-               reject(err);
-          });
+          return resolve(res);
         });
       });
+    }).then(function doUpdate(res) {
+      return new Promise(function(resolve, reject) {
+        $fh.sync.doUpdate(datasetId, res.uid, updateData, function() {
+          return resolve(res);
+        });
+      });
+    }).then(function doRead(res) {
+      return new Promise(function(resolve, reject) {
+        $fh.sync.doRead(datasetId, res.uid, function(data) {
+          return resolve(data);
+        });
+      });
+    }).then(function verifyUpdate(data) {
+      expect(data.data).toEqual(updateData);
+    }, function catchErrors(err) {
+      expect(err).toBeNull();
     });
   });
 

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -83,31 +83,47 @@ describe('Sync', function() {
   });
 
   it('should read', function() {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function manage(resolve, reject) {
       $fh.sync.manage(datasetId, {}, {}, {}, function() {
+        return resolve();
+      })
+    }).then(function doCreate() {
+      return new Promise(function(resolve, reject) {
         $fh.sync.doCreate(datasetId, testData, function(res) {
-          $fh.sync.doRead(datasetId, res.uid, function(data) {
+          return resolve(res);
+        });
+      });
+    }).then(function doRead(res) {
+      return new Promise(function(resolve, reject) {
+        $fh.sync.doRead(datasetId, res.uid, function(data) {
             expect(data.data).toEqual(testData);
             expect(data.hash).not.toBeNull();
             return resolve();
-          }, function(msg) {
-             reject(code + ': ' + msg);
-          });
+        }, function failure(err) {
+           reject(err);
         });
       });
     });
   });
 
   it('should fail when reading unknown uid', function() {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function manage(resolve, reject) {
       $fh.sync.manage(datasetId, {}, {}, {}, function() {
+        return resolve();
+      })
+    }).then(function doCreate() {
+      return new Promise(function(resolve, reject) {
         $fh.sync.doCreate(datasetId, testData, function(res) {
-          $fh.sync.doRead(datasetId, 'bogus uid', function(data) {
-            return reject('doRead should have returned error unknown_uid');
-          }, function(err) {
-            expect(err).toEqual('unknown_uid');
-            resolve();
-          });
+          return resolve(res);
+        });
+      });
+    }).then(function doRead(res) {
+      return new Promise(function(resolve, reject) {
+        $fh.sync.doRead(datasetId, 'bogus uid', function(data) {
+          return reject('Item with uid ' + res.uid + '  should have been deleted');
+        }, function failure(err) {
+           expect(err).toEqual('unknown_uid');
+           resolve();
         });
       });
     });

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -52,6 +52,14 @@ describe('Sync', function() {
   });
 
   it('should create', function() {
+    // set up a notifier that only handles `local_update_applied' events as these might
+    // occur before the then part of the following promise is called.
+    $fh.sync.notify(function(event) {
+      if (event.code === 'local_update_applied') {
+        expect(event.dataset_id).toEqual(datasetId);
+        expect(event.message).toMatch(/(load|create)/);
+      }
+    });
     return new Promise(function(resolve, reject) {
       $fh.sync.manage(datasetId, {}, {}, {}, function() {
         $fh.sync.doCreate(datasetId, testData, function(res) {
@@ -63,19 +71,12 @@ describe('Sync', function() {
         });
       });
     })
-    // .then(waitForSyncEvent('local_update_applied', function(event, resolve, reject) {
-    //   // log: !!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT, local_update_applied, {"dataset_id":"specDataset","uid":null,"code":"local_update_applied","message":"create"}
-    //   expect(event.dataset_id).toEqual(datasetId);
-    //   expect(event.message).toEqual('create');
-    //   return resolve();
-    // }))
-    // .then(waitForSyncEvent('remote_update_applied', function(event, resolve, reject) {
-    //   // log: !!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT, remote_update_applied, {"dataset_id":"specDataset","uid":"589a5c0412c8015f559c1c90","code":"remote_update_applied","message":{"cuid":"B0CF358A9B46455184B26F2FD4DBA1AD","type":"applied","action":"create","hash":"80597a7628eb1d4ee196609c743ea6e759d8cbc6","uid":"589a5c0412c8015f559c1c90","msg":"''"}}
-    //   expect(event.dataset_id).toEqual(datasetId);
-    //   expect(event.message.type).toEqual('applied');
-    //   expect(event.message.action).toEqual('create');
-    //   return resolve();
-    // }));
+    .then(waitForSyncEvent('remote_update_applied', function(event, resolve, reject) {
+       expect(event.dataset_id).toEqual(datasetId);
+       expect(event.message.type).toEqual('applied');
+       expect(event.message.action).toEqual('create');
+       return resolve();
+     }));
   });
 
   // it('should read', function() {

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -49,6 +49,7 @@ describe('Sync', function() {
     }))
     .then(waitForSyncEvent('sync_complete', function(event, resolve, reject) {
       expect(event.dataset_id).toEqual(datasetId);
+      expect(event.message).toEqual('online');
       return resolve();
     }));
   });

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -8,10 +8,9 @@ function waitForSyncEvent(expectedEvent, cb) {
   return function() {
     return new Promise(function(resolve, reject) {
       $fh.sync.notify(function(event) {
-        console.log('!!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT', event.code, JSON.stringify(event));
+        //console.log('!!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT', event.code, JSON.stringify(event));
         if (event.code === expectedEvent) {
           expect(event.code).toEqual(expectedEvent); // keep jasmine happy with at least 1 expectation
-          console.log('!!!! cb', cb);
           if (cb) return cb(event, resolve, reject);
           return resolve();
         }
@@ -49,8 +48,6 @@ describe('Sync', function() {
       return resolve();
     }))
     .then(waitForSyncEvent('sync_complete', function(event, resolve, reject) {
-      // log: !!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT, sync_started, {"dataset_id":"specDataset","uid":null,"code":"sync_started","message":null}
-      // log: !!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT, sync_complete, {"dataset_id":"specDataset","uid":"a2a57278171a23df4441b60238f7802a10e95970","code":"sync_complete","message":"online"}
       expect(event.dataset_id).toEqual(datasetId);
       return resolve();
     }));
@@ -58,7 +55,7 @@ describe('Sync', function() {
 
   it('should create', function() {
     // set up a notifier that only handles `local_update_applied' events as these might
-    // occur before the then part of the following promise is called.
+    // occur before the 'then' part of the following promise being called.
     $fh.sync.notify(function(event) {
       if (event.code === 'local_update_applied') {
         expect(event.dataset_id).toEqual(datasetId);

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -143,19 +143,33 @@ describe('Sync', function() {
     });
   });
 
-  // it('should delete', function() {
-  //   return new Promise(function(resolve, reject) {
-  //     $fh.sync.doDelete(datasetId, dataId, function() {
-  //       $fh.sync.doList(datasetId, function(res) {
-  //         expect(res).toEqual({});
-  //         resolve();
-  //       }, function(code, msg) {
-  //         reject(code + ': ' + msg);
-  //       });
-  //     }, function(code, msg) {
-  //       reject(code + ': ' + msg);
-  //     });
-  //   });
-  // });
+  it('should delete', function() {
+    return new Promise(function manage(resolve, reject) {
+      $fh.sync.manage(datasetId, {}, {}, {}, function() {
+        return resolve();
+      })
+    }).then(function doCreate() {
+      return new Promise(function(resolve, reject) {
+        $fh.sync.doCreate(datasetId, testData, function(res) {
+          return resolve(res);
+        });
+      });
+    }).then(function doDelete(res) {
+      return new Promise(function(resolve, reject) {
+        $fh.sync.doDelete(datasetId, res.uid, function() {
+          return resolve(res);
+        });
+      });
+    }).then(function doRead(res) {
+      return new Promise(function(resolve, reject) {
+        $fh.sync.doRead(datasetId, res.uid, function(data) {
+          return reject('Item with uid ' + res.uid + '  should have been deleted');
+        }, function failure(err) {
+           expect(err).toEqual('unknown_uid');
+           resolve();
+        });
+      });
+    });
+  });
 
 });

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -4,15 +4,14 @@ const updateData = { test: 'something else' };
 var dataId;
 
 
-function waitForSyncEvent(expectedEvent, cb) {
+function waitForSyncEvent(expectedEvent) {
   return function() {
     return new Promise(function(resolve, reject) {
       $fh.sync.notify(function(event) {
         //console.log('!!!!!!!!!!!!!!!!!!!!!!!!!! SYNC_EVENT', event.code, JSON.stringify(event));
         if (event.code === expectedEvent) {
           expect(event.code).toEqual(expectedEvent); // keep jasmine happy with at least 1 expectation
-          if (cb) return cb(event, resolve, reject);
-          return resolve();
+          return resolve(event);
         }
       });
     });
@@ -36,16 +35,16 @@ describe('Sync', function() {
 
   it('should list', function() {
     return manage()
-    .then(waitForSyncEvent('sync_started', function(event, resolve, reject) {
+    .then(waitForSyncEvent('sync_started'))
+    .then(function verifySyncStarted(event) {
       expect(event.dataset_id).toEqual(datasetId);
       expect(event.message).toBeNull();
-      return resolve();
-    }))
-    .then(waitForSyncEvent('sync_complete', function(event, resolve, reject) {
+    })
+    .then(waitForSyncEvent('sync_complete'))
+    .then(function verifySyncCompleted(event) {
       expect(event.dataset_id).toEqual(datasetId);
       expect(event.message).toEqual('online');
-      return resolve();
-    }));
+    });
   });
 
   it('should create', function() {
@@ -63,12 +62,12 @@ describe('Sync', function() {
       expect(res.action).toEqual('create');
       expect(res.post).toEqual(testData);
     })
-    .then(waitForSyncEvent('remote_update_applied', function(event, resolve, reject) {
+    .then(waitForSyncEvent('remote_update_applied'))
+    .then(function verifyUpdateApplied(event) {
        expect(event.dataset_id).toEqual(datasetId);
        expect(event.message.type).toEqual('applied');
        expect(event.message.action).toEqual('create');
-       return resolve();
-     }));
+     });
   });
 
   it('should read', function() {

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -130,61 +130,15 @@ describe('Sync', function() {
   });
 
   it('should update', function() {
-    return new Promise(function manage(resolve, reject) {
-      $fh.sync.manage(datasetId, {}, {}, {}, function() {
-        return resolve();
-      })
-    }).then(function doCreate() {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doCreate(datasetId, testData, function(res) {
-          return resolve(res);
-        });
-      });
-    }).then(function doUpdate(res) {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doUpdate(datasetId, res.uid, updateData, function() {
-          return resolve(res);
-        });
-      });
-    }).then(function doRead(res) {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doRead(datasetId, res.uid, function(data) {
-          return resolve(data);
-        });
-      });
-    }).then(function verifyUpdate(data) {
+    return manage()
+    .then(doCreate)
+    .then(doUpdate())
+    .then(doRead())
+    .then(function verifyUpdate(data) {
       expect(data.data).toEqual(updateData);
-    }, function catchErrors(err) {
+    })
+    .catch(function (err) {
       expect(err).toBeNull();
-    });
-  });
-
-  it('should delete', function() {
-    return new Promise(function manage(resolve, reject) {
-      $fh.sync.manage(datasetId, {}, {}, {}, function() {
-        return resolve();
-      })
-    }).then(function doCreate() {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doCreate(datasetId, testData, function(res) {
-          return resolve(res);
-        });
-      });
-    }).then(function doDelete(res) {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doDelete(datasetId, res.uid, function() {
-          return resolve(res);
-        });
-      });
-    }).then(function doRead(res) {
-      return new Promise(function(resolve, reject) {
-        $fh.sync.doRead(datasetId, res.uid, function(data) {
-          return reject('Item with uid ' + res.uid + '  should have been deleted');
-        }, function failure(err) {
-           expect(err).toEqual('unknown_uid');
-           resolve();
-        });
-      });
     });
   });
 
@@ -195,7 +149,6 @@ describe('Sync', function() {
     .then(doRead())
     .catch(function (err) {
       expect(err).toEqual('unknown_uid');
-      console.log("Catch...", err);
     });
   });
 
@@ -235,7 +188,19 @@ function doRead() {
       $fh.sync.doRead(datasetId, res.uid, function(data) {
         return resolve(data);
       }, function failure(err) {
-         reject(err);
+        reject(err);
+      });
+    });
+  };
+}
+
+function doUpdate() {
+  return function(res) {
+    return new Promise(function(resolve, reject) {
+      $fh.sync.doUpdate(datasetId, res.uid, updateData, function() {
+        return resolve(res);
+      }, function (err) {
+        reject(err);
       });
     });
   };


### PR DESCRIPTION
Currently the local_update_applied events are happing before the 'then'
part of the following promise which means that we are not able to catch
those events. This is a suggestion to add an explicit listener for such
events so that we can verify that that occur and have the expected data.