### PR TITLE
FH-3118 Add afterAll test to syncSpec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+services: mongodb
 node_js:
   - '4.4.7'
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - '4.4.7'
+sudo: false
+install: npm install
+script:
+  - npm test

--- a/application.js
+++ b/application.js
@@ -1,9 +1,10 @@
-var mbaasApi = require('fh-mbaas-api');
-var express = require('express');
-var mbaasExpress = mbaasApi.mbaasExpress();
-var cors = require('cors');
+const async = require('async');
+const mbaasApi = require('fh-mbaas-api');
+const express = require('express');
+const mbaasExpress = mbaasApi.mbaasExpress();
+const cors = require('cors');
 
-var app = express();
+const app = express();
 
 // Enable CORS for all requests
 app.use(cors());
@@ -18,6 +19,8 @@ app.use(express.static(__dirname + '/public'));
 // Note: important that this is added just before your own Routes
 app.use(mbaasExpress.fhmiddleware());
 
+app.post('/dataset/:datasetId/reset', resetDataset);
+
 // Important that this is last!
 app.use(mbaasExpress.errorHandler());
 
@@ -27,6 +30,39 @@ var server = app.listen(port, host, function() {
   console.log("App started at: " + new Date() + " on port: " + port); 
 });
 
+/**
+ * Request handler to delete all collections in MongoDB for a provided dataset.
+ */
+function resetDataset(req, res) {
+  // Define titles for default, updates and collision collections in MongoDB.
+  const dataset = req.params.datasetId;
+  const updates = dataset + '-updates';
+  const collisions = dataset + '-collision';
+
+  // Delete all records in the MongoDB collections for the dataset.
+  async.forEach([dataset, updates, collisions], function(collection, cb) {
+    // If this fails we don't want the test to fail.
+    resetCollection(collection, cb);
+  }, function(err) {
+    if (err) {
+      return res.json({error: err }).status(500);
+    }
+    return res.json({message: 'Dataset ' + dataset + ' reset'}).status(200);
+  });
+};
+
+/**
+ * Remove all records for a particular collection in MongoDB.
+ * 
+ * @param {string} collection - Name of the MongoDB collection.
+ * @param {Function} cb - Callback function.
+ */
+function resetCollection(collection, cb) {
+  mbaasApi.db({
+    act: 'deleteall',
+    type: collection
+  }, cb);
+};
 
 module.exports = {
   app: app,

--- a/main.js
+++ b/main.js
@@ -12390,7 +12390,6 @@ var self = {
         failure("unknown_uid");
       } else {
         // Return a copy of the record so updates will not automatically make it back into the dataset
-        console.log(JSON.stringify(rec));
         var res = JSON.parse(JSON.stringify(rec));
         success(res);
       }
@@ -13601,6 +13600,5 @@ module.exports = {
 },{"./appProps":29,"./constants":31,"./data":33,"./events":35,"./fhparams":36,"./hosts":38,"./initializer":39,"./logger":42}]},{},[19])
 (19)
 });
-
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{}]},{},[1]);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "async": "^2.1.4",
     "browserify": "^14.0.0",
     "browserify-shim": "^3.8.13",
     "connect": "^3.5.0",

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -28,6 +28,13 @@ describe('Sync', function() {
     $fh.sync.stopSync(datasetId, done, done.fail);
   });
 
+  afterAll(function() {
+    return new Promise(function(resolve, reject) {
+      // We don't want to fail the test if the data isn't removed so resolve.
+      $fh.cloud({ path: '/dataset/' + datasetId + '/reset' }, resolve, resolve);
+    });
+  })
+
   it('should manage a dataset', function() {
     $fh.sync.manage(datasetId);
     return waitForSyncEvent('sync_complete')();


### PR DESCRIPTION
Currently four records are created in the MongoDB collections for
the tests. These are now deleted when all tests end.