### PR TITLE
FH-3114 Test causing a collision from $fh.sync

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ grunt.registerTask('startServers', function startServers() {
   process.env.FH_USE_LOCAL_DB = true;
   const done = this.async();
   cloudServer = require('./application.js').server;
-  clientServer = connect().use(serveStatic(__dirname)).listen(9002, function(){
+  clientServer = connect().use(serveStatic(__dirname)).listen(9002, function() {
     console.log('server listening');
     return done();
   });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "async": "^2.1.4",
+    "body-parser": "^1.16.1",
     "browserify": "^14.0.0",
     "browserify-shim": "^3.8.13",
     "connect": "^3.5.0",


### PR DESCRIPTION
This adds a test which will perform the following steps:

  * Create a record.
  * Update a record.
  * Wait for the UID of the record to be returned.
  * Update the MongoDB record with the UID without the sync client.
  * Update the same record with the sync client, this will cause a collision.
  * Wait for the collision to be reported back to the client.
  * Ensure `listCollisions` includes the collision record.
  * Remove the collision using `removeCollision`.
  * Ensure `listCollisions` no longer includes the client record (Is always up to date).

This asserts the current behaviour of a collision on the client.