### PR TITLE
Clients should create and update based on remote changes

### DIFF
--- a/application.js
+++ b/application.js
@@ -24,6 +24,7 @@ app.use(express.static(__dirname + '/public'));
 app.use(mbaasExpress.fhmiddleware());
 
 app.post('/datasets/:datasetId/reset', resetDataset);
+app.post('/datasets', createDataset);
 app.post('/datasets/:datasetId/records', createRecord);
 app.put('/datasets/:datasetId/records/:recordId', updateRecord);
 
@@ -112,5 +113,20 @@ function createRecord(req, res) {
       return res.json({ error: err }).status(500);
     }
     return res.json({ data: data }).status(200);
+  });
+}
+
+/**
+ * Create a dataset with the provided options.
+ */
+function createDataset(req, res) {
+  const datasetName = req.body.name;
+  const datasetOptions = req.body.options;
+
+  mbaasApi.sync.init(datasetName, datasetOptions, function(err, dataset) {
+    if (err) {
+      return res.json({ error: err }).status(500);
+    }
+    return res.json({ data: dataset }).status(200);
   });
 }

--- a/application.js
+++ b/application.js
@@ -23,8 +23,9 @@ app.use(express.static(__dirname + '/public'));
 // Note: important that this is added just before your own Routes
 app.use(mbaasExpress.fhmiddleware());
 
-app.post('/dataset/:datasetId/reset', resetDataset);
-app.post('/dataset/:datasetId/record/:recordId', updateRecord);
+app.post('/datasets/:datasetId/reset', resetDataset);
+app.post('/datasets/:datasetId/records', createRecord);
+app.put('/datasets/:datasetId/records/:recordId', updateRecord);
 
 // Important that this is last!
 app.use(mbaasExpress.errorHandler());
@@ -86,6 +87,25 @@ function updateRecord(req, res) {
     act: 'update',
     type: dataset,
     guid: record,
+    fields: recordData
+  }, function(err, data) {
+    if (err) {
+      return res.json({ error: err }).status(500);
+    }
+    return res.json({ data: data }).status(200);
+  });
+}
+
+/**
+ * Create a record in a particular dataset.
+ */
+function createRecord(req, res) {
+  const dataset = req.params.datasetId;
+  const recordData = req.body.data;
+
+  mbaasApi.db({
+    act: 'create',
+    type: dataset,
     fields: recordData
   }, function(err, data) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-acceptance-testing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -4,6 +4,16 @@ const updateData = { test: 'something else' };
 
 describe('Sync', function() {
 
+  beforeAll(function(done) {
+    $fh.cloud({
+      path: '/datasets',
+      data: {
+        name: 'specDataset',
+        options: { syncFrequency: 1 }
+      }
+    }, done, done.fail);
+  });
+
   beforeEach(function() {
     $fh.sync.init({ sync_frequency: 1, storage_strategy: 'dom' });
   });
@@ -12,11 +22,8 @@ describe('Sync', function() {
     $fh.sync.stopSync(datasetId, done, done.fail);
   });
 
-  afterAll(function() {
-    return new Promise(function(resolve, reject) {
-      // We don't want to fail the test if the data isn't removed so resolve.
-      $fh.cloud({ path: '/datasets/' + datasetId + '/reset' }, resolve, reject);
-    });
+  afterAll(function(done) {
+    $fh.cloud({ path: '/datasets/' + datasetId + '/reset' }, done, done.fail);
   });
 
   it('should manage a dataset', function() {
@@ -146,7 +153,7 @@ describe('Sync', function() {
     .catch(function(err) {
       expect(err).toBeNull();
     });
-  }, 60000);
+  });
 
   it('should create records created by other clients', function() {
     const recordToCreate = { test: 'create' };
@@ -167,7 +174,7 @@ describe('Sync', function() {
     .catch(function(err) {
       expect(err).toBeNull();
     });
-  }, 60000);
+  });
 
   it('should update records updated by other clients', function() {
     const updateData = { test: 'cause a client update' };
@@ -191,7 +198,7 @@ describe('Sync', function() {
     .catch(function(err) {
       expect(err).toBeNull();
     });
-  }, 60000);
+  });
 });
 
 function manage() {


### PR DESCRIPTION
Currently we have no tests around clients syncing changes which have
been made by other clients. This adds two tests:

  1. Update the dataset collection in MongoDB with a new record and
     assert that this record is then received by the client and the
     client updates this locally.

  2. Update the dataset collection in MongoDB with a changed record
     and assert that this record is updated on the sync client also.

Both of the tests also assert the notification sent out by the client
when handling these changes, `record_delta_received` and verifies its
structure.

This also requires a change to the server to add a create record
endpoint at `/datasets/:datasetId/records` along with updating the
update record endpoint to be a `PUT` endpoint, instead of a `POST`.