### PR TITLE
FH-3130 Assert behaviour when server crashes for a period of time

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,42 +1,32 @@
 <!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Jasmine Spec Runner</title>
-  <link rel="shortcut icon" type="image/png" href=".grunt/grunt-contrib-jasmine/jasmine_favicon.png">
+  <head>
+    <meta charset="utf-8">
+    <title>Jasmine Spec Runner</title>
+    <link rel="shortcut icon" type="image/png" href=".grunt/grunt-contrib-jasmine/jasmine_favicon.png">
+    <link rel="stylesheet" type="text/css" href=".grunt/grunt-contrib-jasmine/jasmine.css">
+  </head>
+  <body>
+    <script src=".grunt/grunt-contrib-jasmine/jasmine.js"></script>
+    
+    <script src=".grunt/grunt-contrib-jasmine/jasmine-html.js"></script>
+    
+    <script src=".grunt/grunt-contrib-jasmine/json2.js"></script>
+    
+    <script src=".grunt/grunt-contrib-jasmine/boot.js"></script>
 
-  <link rel="stylesheet" type="text/css" href=".grunt/grunt-contrib-jasmine/jasmine.css">
+    <script src="node_modules/babel-polyfill/dist/polyfill.js"></script>
 
+    <script src="node_modules/jasmine-promises/dist/jasmine-promises.js"></script>
+    
+    <script src="main.js"></script>
 
-</head>
-<body>
-
-  
-  <script src=".grunt/grunt-contrib-jasmine/jasmine.js"></script>
-  
-  <script src=".grunt/grunt-contrib-jasmine/jasmine-html.js"></script>
-  
-  <script src=".grunt/grunt-contrib-jasmine/json2.js"></script>
-  
-  <script src=".grunt/grunt-contrib-jasmine/boot.js"></script>
-
-  <script src="node_modules/babel-polyfill/dist/polyfill.js"></script>
-
-  <script src="node_modules/jasmine-promises/dist/jasmine-promises.js"></script>
-  
-
-  <script src="main.js"></script>
-
-  <script>
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
-  </script>
-
-  
-  <!--/*<script src="spec/fhSyncCreateSpec.js"></script>*/-->
-  <script src="spec/syncSpec.js"></script>
-  
-  <script src=".grunt/grunt-contrib-jasmine/reporter.js"></script>
-  
-
-</body>
+    <script>
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+    </script>
+    
+    <script src="spec/syncSpec.js"></script>
+    
+    <script src=".grunt/grunt-contrib-jasmine/reporter.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
This adds a single test that performs the following tasks:

  * Put the sync portion of the server into `crashed` mode.
  * Create a record on the client.
  * Assert that the sync between client and server fails.
  * Put the sync portion of the server into `running` mode.
  * Assert that the record is eventually created on the server.

The `running` and `crashed` states of the server are activated by
calling an endpoint `POST /server/status` with a body in the format
of:

```json
{
  "status": {
    "crashed": true
  }
}
```

Using a mock tool like `nock` didn't seem to be working, so this was
the solution I decided upon.