### PR TITLE
FH-3151 Assert getUID behaviour

### DIFF
--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -375,6 +375,25 @@ describe('Sync', function() {
       });
   });
 
+  it('should update uid after remote update', function() {
+    return manage(datasetId)
+    .then(doCreate(datasetId, testData))
+    .then(function(record) {
+      return new Promise(function verifyUidIsHash(resolve) {
+        const recordUid = $fh.sync.getUID(record.hash);
+        expect(record.hash).toEqual(recordUid);
+        resolve();
+      })
+      .then(waitForSyncEvent('remote_update_applied'))
+      .then(function verifyUidIsUpdated(event) {
+        const recordUid = $fh.sync.getUID(record.hash);
+        expect(event.uid).toEqual(recordUid);
+      });
+    })
+    .catch(function(err) {
+      expect(err).toBeNull();
+    });
+  });
 });
 
 function offline() {


### PR DESCRIPTION
`getUID` references a map that contains hashes of records with the UID
of that record in MongoDB. This is because when a record is first created
it is given a temporary UID, its hash. At this point `getUID` will not
contain the `Hash -> UID` map so it will just return back the records hash
to act as the temporary UID.

When the record is updated remotely the updated, permanent, UID will be
returned to the client. This is then added to the `Hash -> UID` map, from
this point on passing the records hash to `getUID` will return the MongoDB
UID.

This adds a test which will perform the actions above and assert that the
correct values are being returned depending on whether the remove update
has been made yet.

  * Create a record
  * Assert that `getUID` returns the records hash (temporary UID).
  * Wait for the remote update to be applied.
  * Assert that `getUID` returns the records permanent UID.