### PR TITLE
move babel-polyfill to polyfills section

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,8 +32,10 @@ module.exports = function(grunt) {
           host: 'http://localhost:9002',
           outfile: 'index.html?url=http://localhost:8001',
           specs: 'spec/*Spec.js',
+          polyfills: [
+            './node_modules/babel-polyfill/dist/polyfill.js'
+          ],
           vendor: [
-            './node_modules/babel-polyfill/dist/polyfill.js',
             './node_modules/jasmine-promises/dist/jasmine-promises.js'
           ],
           template: require('./tasks/template.js'),


### PR DESCRIPTION
Motivation:
This is very minor but moving the babel-polyfill to the jasmine options
polyfills array instead of the vendor option. This will cause the
polyfill to come before the jasmine specific scripts in the generated
spec runner (index.html in our case)