### PR TITLE
Fix inter test dependency on sync events

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
         src: 'main.js',
         options: {
           host: 'http://localhost:9002',
-          outfile: 'index.html?url=http://localhost:8001',
+          outfile: 'index.html?url=http://localhost:8001&throwFailures=true',
           specs: 'spec/*Spec.js',
           polyfills: [
             './node_modules/babel-polyfill/dist/polyfill.js'

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -170,6 +170,35 @@ function waitForSyncEvent(expectedEvent) {
 }
 
 /**
+ * Verifies the given events are not seen/notified for the specific number of milliseconds
+ *
+ * @param {string[]} events event names to verify do not occur
+ * @param {number} timeout time to wait before the verification is complete
+ */
+function verifyAbsenceOfEvents(events, timeout) {
+  return function() {
+    return new Promise(function(resolve, reject) {
+      // resolve if the specified amount of time has passed,
+      // and prevent rejection being called by removing our notification listener
+      var resolveTimeout = setTimeout(function() {
+        $fh.sync.notify(function() {});
+        resolve();
+      }, timeout);
+
+      // reject if any of the specified events are seen, and clear the resolve timeout to
+      // prevent resolution
+      $fh.sync.notify(function(event) {
+        if (events.indexOf(event.code) > -1) {
+          clearTimeout(resolveTimeout);
+          $fh.sync.notify(function() {});
+          return reject('Event was seen when it shouldn\'t have been (' + event.code + ')');
+        }
+      });
+    });
+  };
+}
+
+/**
  * Set the server into or out of a crashed state with a custom response status.
  *
  * @param {Object} status - The status object.

--- a/tasks/Runner.tmpl
+++ b/tasks/Runner.tmpl
@@ -16,7 +16,7 @@
   <% }) %>
 <% }; %>
   <script>
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
   </script>
 </body>
 </html>


### PR DESCRIPTION
This change is the result of running single tests in isolation, and
seeing failures.
The changes are:
* stop syncing of all potential test datasets after every test
* verify absence of particular sync events while sync is stopped
* only start back up sync after the sync frequency has passed
* lower the sync frequency to 0.5 seconds to speed up tests
* clear local storage after every test to ensure no cross-test problems
* lower jasmine test timeout to speed up test run on failures