### PR TITLE
🔨  Use a different dataset for each test to avoid test interference

### DIFF
--- a/spec/syncCrudSpec.js
+++ b/spec/syncCrudSpec.js
@@ -1,43 +1,39 @@
-const datasetId = 'specDataset';
-const datasetOneId = 'specDatasetOne';
-const datasetTwoId = 'specDatasetTwo';
 const testData = { test: 'text' };
 const updateData = { test: 'something else' };
+var currentDatasetIds = [];
 
 describe('Sync Create/Update/Delete', function() {
 
-  beforeAll(function(done) {
+  beforeAll(function() {
     localStorage.clear();
-    $fh.cloud({
-      path: '/datasets',
-      data: {
-        name: 'specDataset',
-        options: { syncFrequency: 0.5 }
-      }
-    }, done, done.fail);
   });
 
   beforeEach(function() {
+    currentDatasetIds = [];
     $fh.sync.init({ sync_frequency: 0.5, storage_strategy: 'dom' , crashed_count_wait: 1});
   });
 
   afterEach(function(done) {
-    var datasets = [datasetId, datasetOneId, datasetTwoId];
+    if (currentDatasetIds.length === 0) {
+      return done();
+    }
+
     var datasetsStopped = 0;
 
     function datasetStopped() {
       datasetsStopped++;
-      if (datasetsStopped === datasets.length) {
+      if (datasetsStopped === currentDatasetIds.length) {
         localStorage.clear();
         return done();
       }
     }
 
-    datasets.forEach(function(dataset) {
+    // Stop any managed datasets
+    currentDatasetIds.forEach(function(dataset) {
       $fh.sync.stopSync(dataset, function() {
         datasetStopped();
       }, function() {
-        console.info('Problem stopping sync for dataset ' + dataset + '. This can be ignored if the dataset was not "managed" in the test');
+        // ignore any errors
         datasetStopped();
       });
     });
@@ -45,22 +41,28 @@ describe('Sync Create/Update/Delete', function() {
   });
 
   afterAll(function() {
-    return removeDataset(datasetId)();
+    currentDatasetIds.forEach(function(datasetId) {
+      removeDataset(datasetId)();
+    });
   });
 
   it('should manage a dataset', function() {
+    const datasetId = 'shoudManage';
+    currentDatasetIds.push(datasetId);
     $fh.sync.manage(datasetId);
-    return waitForSyncEvent('sync_complete')();
+    return waitForSyncEvent('sync_complete', datasetId)();
   });
 
   it('should list', function() {
+    const datasetId = 'shouldList';
+    currentDatasetIds.push(datasetId);
     return manage(datasetId)
-    .then(waitForSyncEvent('sync_started'))
+    .then(waitForSyncEvent('sync_started', datasetId))
     .then(function verifySyncStarted(event) {
       expect(event.dataset_id).toEqual(datasetId);
       expect(event.message).toBeNull();
     })
-    .then(waitForSyncEvent('sync_complete'))
+    .then(waitForSyncEvent('sync_complete', datasetId))
     .then(function verifySyncCompleted(event) {
       expect(event.dataset_id).toEqual(datasetId);
       expect(event.message).toEqual('online');
@@ -68,10 +70,12 @@ describe('Sync Create/Update/Delete', function() {
   });
 
   it('should create', function() {
+    const datasetId = 'shouldCreate';
+    currentDatasetIds.push(datasetId);
     // set up a notifier that only handles `local_update_applied' events as these might
     // occur before the 'then' part of the following promise being called.
     $fh.sync.notify(function(event) {
-      if (event.code === 'local_update_applied') {
+      if (event.dataset_id === datasetId && event.code === 'local_update_applied') {
         expect(event.dataset_id).toEqual(datasetId);
         expect(event.message).toMatch(/(load|create)/);
       }
@@ -82,7 +86,7 @@ describe('Sync Create/Update/Delete', function() {
       expect(res.action).toEqual('create');
       expect(res.post).toEqual(testData);
     })
-    .then(waitForSyncEvent('remote_update_applied'))
+    .then(waitForSyncEvent('remote_update_applied', datasetId))
     .then(function verifyUpdateApplied(event) {
       expect(event.dataset_id).toEqual(datasetId);
       expect(event.message.type).toEqual('applied');
@@ -91,6 +95,8 @@ describe('Sync Create/Update/Delete', function() {
   });
 
   it('should read', function() {
+    const datasetId = 'shoudRead';
+    currentDatasetIds.push(datasetId);
     return manage(datasetId)
     .then(doCreate(datasetId, testData))
     .then(function withResult(res) {
@@ -102,22 +108,28 @@ describe('Sync Create/Update/Delete', function() {
       });
     })
     .catch(function(err) {
+      console.error(err, err.stack);
       expect(err).toBeNull();
     });
   });
 
   it('should fail when reading unknown uid', function() {
+    const datasetId = 'shouldFailUnknownUID';
+    currentDatasetIds.push(datasetId);
     return manage(datasetId)
     .then(doCreate(datasetId, testData))
     .then(function withResult() {
       return doRead(datasetId, 'bogus_uid');
     })
     .catch(function verifyError(err) {
+      console.error(err, err.stack);
       expect(err).toEqual('unknown_uid');
     });
   });
 
   it('should update', function() {
+    const datasetId = 'shouldUpdate';
+    currentDatasetIds.push(datasetId);
     return manage(datasetId)
     .then(doCreate(datasetId, testData))
     .then(function withResult(res) {
@@ -129,11 +141,14 @@ describe('Sync Create/Update/Delete', function() {
       });
     })
     .catch(function(err) {
+      console.error(err, err.stack);
       expect(err).toBeNull();
     });
   });
 
   it('should delete', function() {
+    const datasetId = 'shoudDelete';
+    currentDatasetIds.push(datasetId);
     return manage(datasetId)
       .then(doCreate(datasetId, testData))
       .then(function withResult(res) {
@@ -146,11 +161,13 @@ describe('Sync Create/Update/Delete', function() {
   });
 
   it('should create records created by other clients', function() {
+    const datasetId = 'shouldCreateRecordsByOtherClients';
+    currentDatasetIds.push(datasetId);
     const recordToCreate = { test: 'create' };
 
     return manage(datasetId)
     .then(createRecord(datasetId, recordToCreate))
-    .then(waitForSyncEvent('record_delta_received'))
+    .then(waitForSyncEvent('record_delta_received', datasetId))
     .then(function verifyDeltaStructure(event) {
       expect(event.uid).not.toBeNull();
       expect(event.message).toEqual('create');
@@ -160,21 +177,24 @@ describe('Sync Create/Update/Delete', function() {
         expect(record.data).toEqual(recordToCreate);
       })
       .catch(function(err) {
+        console.error(err, err.stack);
         expect(err).toBeNull();
       });
     });
   });
 
   it('should update records updated by other clients', function() {
+    const datasetId = 'shouldUpdateRecordsByOtherClients';
+    currentDatasetIds.push(datasetId);
     const updateData = { test: 'cause a client update' };
 
     return manage(datasetId)
     .then(doCreate(datasetId, testData))
-    .then(waitForSyncEvent('remote_update_applied'))
+    .then(waitForSyncEvent('remote_update_applied', datasetId))
     .then(function verifyUpdateApplied(event) {
       const uid = event.uid;
       return updateRecord(datasetId, uid, updateData)
-      .then(waitForSyncEvent('record_delta_received'))
+      .then(waitForSyncEvent('record_delta_received', datasetId))
       .then(function verifyDeltaStructure(event) {
         expect(event.message).toEqual('update');
         return doRead(datasetId, event.uid);
@@ -184,11 +204,16 @@ describe('Sync Create/Update/Delete', function() {
       });
     })
     .catch(function(err) {
+      console.error(err, err.stack);
       expect(err).toBeNull();
     });
   });
 
   it('should manage multiple datasets', function() {
+    const datasetOneId = 'shoudManageMultipleDatasets1';
+    const datasetTwoId = 'shoudManageMultipleDatasets2';
+    currentDatasetIds.push(datasetOneId);
+    currentDatasetIds.push(datasetTwoId);
 
     const recordOne = { test: 'recordOne' };
     const recordTwo = { test: 'recordTwo' };
@@ -199,13 +224,13 @@ describe('Sync Create/Update/Delete', function() {
     return manage(datasetOneId)
     .then(manage(datasetTwoId))
     .then(doCreate(datasetOneId, recordOne))
-    .then(waitForSyncEvent('remote_update_applied'))
+    .then(waitForSyncEvent('remote_update_applied', datasetOneId))
     .then(function setRecordTwoHash(event) {
       expect(event.uid).not.toBeNull();
       recordOneHash = event.uid;
     })
     .then(doCreate(datasetTwoId, recordTwo))
-    .then(waitForSyncEvent('remote_update_applied'))
+    .then(waitForSyncEvent('remote_update_applied', datasetTwoId))
     .then(function setRecordTwoHash(event) {
       expect(event.uid).not.toBeNull();
       recordTwoHash = event.uid;
@@ -225,11 +250,14 @@ describe('Sync Create/Update/Delete', function() {
     .then(removeDataset(datasetOneId))
     .then(removeDataset(datasetTwoId))
     .catch(function(err) {
+      console.error(err, err.stack);
       expect(err).toBeNull();
     });
   });
 
   it('should update uid after remote update', function() {
+    const datasetId = 'shoudUpdateUIDAfterRemoteUpdate';
+    currentDatasetIds.push(datasetId);
     return manage(datasetId)
     .then(doCreate(datasetId, testData))
     .then(function(record) {
@@ -238,13 +266,14 @@ describe('Sync Create/Update/Delete', function() {
         expect(record.hash).toEqual(recordUid);
         resolve();
       })
-      .then(waitForSyncEvent('remote_update_applied'))
+      .then(waitForSyncEvent('remote_update_applied', datasetId))
       .then(function verifyUidIsUpdated(event) {
         const recordUid = $fh.sync.getUID(record.hash);
         expect(event.uid).toEqual(recordUid);
       });
     })
     .catch(function(err) {
+      console.error(err, err.stack);
       expect(err).toBeNull();
     });
   });


### PR DESCRIPTION
* Move from a single dataset used by all tests to different datasets
* Each dataset is 'managed' and cleaned up before/after each test
* Logging of stacktrace on failures added (origin suppressed by promise)