### PR TITLE
🐛 FH-3197 Changes to support running tests agains sync scaling changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-services: mongodb
+services: docker
 node_js:
   - '4.4.7'
 sudo: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ var cloudServer;
 var clientServer;
 
 grunt.registerTask('startServers', function startServers() {
-  process.env.FH_USE_LOCAL_DB = true;
+  process.env.FH_MONGODB_CONN_URL="mongodb://test:test@localhost:27017/test";
   const done = this.async();
   cloudServer = require('./application.js').server;
   clientServer = connect().use(serveStatic(__dirname)).listen(9002, function() {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "pretest": "./scripts/pretest.sh",
+    "posttest": "./scripts/posttest.sh",
     "test": "browserify app.js > main.js && grunt -v"
   },
   "author": "",
@@ -17,7 +19,7 @@
     "cors": "^2.8.1",
     "express": "^4.14.1",
     "fh-js-sdk": "^2.18.2",
-    "fh-mbaas-api": "^6.1.5",
+    "fh-mbaas-api": "^6.1.6",
     "grunt": "^1.0.1",
     "grunt-contrib-jasmine": "^1.1.0",
     "serve-static": "^1.11.2"

--- a/scripts/posttest.sh
+++ b/scripts/posttest.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+docker rm -f $(docker ps -a -q  --filter name=mongodb2.4)
+echo "Mongodb Stopped"
+docker rm -f $(docker ps -a -q  --filter name=redis2.6)
+echo "Redis Stopped"

--- a/scripts/pretest.sh
+++ b/scripts/pretest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+echo "Starting Redis-2.6"
+docker pull redis:2.6
+docker rm -f $(docker ps -a -q  --filter name=redis2.6)
+docker run -d -p 127.0.0.1:6379:6379 --name redis2.6 redis:2.6
+echo "Starting Mongodb-2.4"
+docker pull mongo:2.4
+docker rm -f $(docker ps -a -q  --filter name=mongodb2.4)
+docker run -d -p 127.0.0.1:27017:27017 --name mongodb2.4 mongo:2.4 mongod --smallfiles
+#give it some time to complete starting
+sleep 10s
+docker exec mongodb2.4 mongo test --eval "db.addUser({user: 'test',pwd: 'test',roles: ['userAdminAnyDatabase']})"

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -16,19 +16,21 @@ function setOnline(online) {
 }
 
 function manage(dataset, options) {
-  return new Promise(function(resolve, reject) {
-    $fh.cloud({
-      path: '/datasets',
-      data: {
-        name: dataset,
-        options: { syncFrequency: 0.5 }
-      }
-    }, function() {
-      $fh.sync.manage(dataset, options, {}, {}, function() {
-        resolve();
-      });
-    }, reject);
-  });
+  return function() {
+    return new Promise(function(resolve, reject) {
+      $fh.cloud({
+        path: '/datasets',
+        data: {
+          name: dataset,
+          options: { syncFrequency: 0.5 }
+        }
+      }, function() {
+        $fh.sync.manage(dataset, options, {}, {}, function() {
+          resolve();
+        });
+      }, reject);
+    });
+  };
 }
 
 function clearCache(datasetId) {

--- a/spec/syncCrudSpec.js
+++ b/spec/syncCrudSpec.js
@@ -56,7 +56,7 @@ describe('Sync Create/Update/Delete', function() {
   it('should list', function() {
     const datasetId = 'shouldList';
     currentDatasetIds.push(datasetId);
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(waitForSyncEvent('sync_started', datasetId))
     .then(function verifySyncStarted(event) {
       expect(event.dataset_id).toEqual(datasetId);
@@ -80,7 +80,7 @@ describe('Sync Create/Update/Delete', function() {
         expect(event.message).toMatch(/(load|create)/);
       }
     });
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(doCreate(datasetId, testData))
     .then(function(res) {
       expect(res.action).toEqual('create');
@@ -97,7 +97,7 @@ describe('Sync Create/Update/Delete', function() {
   it('should read', function() {
     const datasetId = 'shoudRead';
     currentDatasetIds.push(datasetId);
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(doCreate(datasetId, testData))
     .then(function withResult(res) {
       const uid = res.uid;
@@ -116,13 +116,12 @@ describe('Sync Create/Update/Delete', function() {
   it('should fail when reading unknown uid', function() {
     const datasetId = 'shouldFailUnknownUID';
     currentDatasetIds.push(datasetId);
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(doCreate(datasetId, testData))
     .then(function withResult() {
       return doRead(datasetId, 'bogus_uid');
     })
     .catch(function verifyError(err) {
-      console.error(err, err.stack);
       expect(err).toEqual('unknown_uid');
     });
   });
@@ -130,7 +129,7 @@ describe('Sync Create/Update/Delete', function() {
   it('should update', function() {
     const datasetId = 'shouldUpdate';
     currentDatasetIds.push(datasetId);
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(doCreate(datasetId, testData))
     .then(function withResult(res) {
       const uid = res.uid;
@@ -149,7 +148,7 @@ describe('Sync Create/Update/Delete', function() {
   it('should delete', function() {
     const datasetId = 'shoudDelete';
     currentDatasetIds.push(datasetId);
-    return manage(datasetId)
+    return manage(datasetId)()
       .then(doCreate(datasetId, testData))
       .then(function withResult(res) {
         const uid = res.uid;
@@ -165,7 +164,7 @@ describe('Sync Create/Update/Delete', function() {
     currentDatasetIds.push(datasetId);
     const recordToCreate = { test: 'create' };
 
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(createRecord(datasetId, recordToCreate))
     .then(waitForSyncEvent('record_delta_received', datasetId))
     .then(function verifyDeltaStructure(event) {
@@ -188,7 +187,7 @@ describe('Sync Create/Update/Delete', function() {
     currentDatasetIds.push(datasetId);
     const updateData = { test: 'cause a client update' };
 
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(doCreate(datasetId, testData))
     .then(waitForSyncEvent('remote_update_applied', datasetId))
     .then(function verifyUpdateApplied(event) {
@@ -221,7 +220,7 @@ describe('Sync Create/Update/Delete', function() {
     var recordOneHash;
     var recordTwoHash;
 
-    return manage(datasetOneId)
+    return manage(datasetOneId)()
     .then(manage(datasetTwoId))
     .then(doCreate(datasetOneId, recordOne))
     .then(waitForSyncEvent('remote_update_applied', datasetOneId))
@@ -258,7 +257,7 @@ describe('Sync Create/Update/Delete', function() {
   it('should update uid after remote update', function() {
     const datasetId = 'shoudUpdateUIDAfterRemoteUpdate';
     currentDatasetIds.push(datasetId);
-    return manage(datasetId)
+    return manage(datasetId)()
     .then(doCreate(datasetId, testData))
     .then(function(record) {
       return new Promise(function verifyUidIsHash(resolve) {


### PR DESCRIPTION
* Use docker for running mongodb to allow common testing prereqs
* Setup a mongodb test user to trigger 'upgraded db' mode in fh-db
* Explicitly specify the mongo connection url for the test server
* Use the branch of fh-mbaas-api with sync scaling changes
* Fix an issue with sync.manage to return a Promise
* Allow for slightly different behaviour when stopping & forcing sync. Specificially, do a second force sync to ensure our updates were applied.