### PR TITLE
Bump fh-mbaas-api dependency to ^7.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cors": "^2.8.1",
     "express": "^4.14.1",
     "fh-js-sdk": "^2.18.2",
-    "fh-mbaas-api": "^6.1.6",
+    "fh-mbaas-api": "^7.0.4",
     "grunt": "^1.0.1",
     "grunt-contrib-jasmine": "^1.1.0",
     "serve-static": "^1.11.2"


### PR DESCRIPTION
Currently, when running `npm test` from this project fh-mbaas-api@6
will be tested.

It's probably best to have this as the latest fh-mbaas-api version by default.