### PR TITLE
Remove duplicate test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-acceptance-testing",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/spec/syncSpec.js
+++ b/spec/syncSpec.js
@@ -275,28 +275,4 @@ describe('Sync', function() {
           .then(manage(datasetId))); // this is to keep afterEach from failing
       });
   });
-
-
-  it('should update uid after remote update', function() {
-    const datasetId = 'shoudUpdateUIDAfterRemoteUpdate';
-    currentDatasetIds.push(datasetId);
-    return manage(datasetId)()
-    .then(doCreate(datasetId, testData))
-    .then(function(record) {
-      return new Promise(function verifyUidIsHash(resolve) {
-        const recordUid = $fh.sync.getUID(record.hash);
-        expect(record.hash).toEqual(recordUid);
-        resolve();
-      })
-      .then(waitForSyncEvent('remote_update_applied', datasetId))
-      .then(function verifyUidIsUpdated(event) {
-        const recordUid = $fh.sync.getUID(record.hash);
-        expect(event.uid).toEqual(recordUid);
-      });
-    })
-    .catch(function(err) {
-      console.error(err, err.stack);
-      expect(err).toBeNull();
-    });
-  });
 });


### PR DESCRIPTION
Currently the `should update uid after remote update` test is being
executed twice. Once from `syncSpec` and once from `syncCrudSpec`.

This removes the duplicate test from `syncSpec` as the test is around
updating records.